### PR TITLE
use pangeo-docker-images 2021.12.02

### DIFF
--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,3 +1,3 @@
-FROM pangeo/pangeo-notebook:2022.02.04
+FROM pangeo/pangeo-notebook:2021.12.02
 
 RUN conda install -n notebook -c conda-forge pangeo-forge-recipes jupytext rich


### PR DESCRIPTION
This will make this image compatible with nbgitpuller on https://hub.aws-uswest2-binder.pangeo.io, as described in https://github.com/pangeo-data/pangeo-docker-images/issues/272#issuecomment-1058390957